### PR TITLE
Make publicKeyPath and privateKeyPath optional

### DIFF
--- a/src/commands/crypt.ts
+++ b/src/commands/crypt.ts
@@ -59,7 +59,7 @@ export namespace commands {
         }
 
         protected buildExecString(): string {
-            return `${this.currentConfig.eyamlPath} decrypt --stdin --pkcs7-public-key "${this.currentConfig.publicKeyPath}" --pkcs7-private-key "${this.currentConfig.privateKeyPath}"`;
+            return `${this.currentConfig.eyamlPath} decrypt --stdin${this.currentConfig.publicKeyPath ? " --pkcs7-public-key " + this.currentConfig.publicKeyPath : ""}${this.currentConfig.privateKeyPath ? " --pkcs7-private-key " + this.currentConfig.privateKeyPath : ""}`;
         }
 
         protected prepareInput(input: string): string {
@@ -76,7 +76,7 @@ export namespace commands {
         }
 
         protected buildExecString(): string {
-            return `${this.currentConfig.eyamlPath} encrypt -o ${this.currentConfig.outputFormat} --stdin --pkcs7-public-key "${this.currentConfig.publicKeyPath}"`;
+            return `${this.currentConfig.eyamlPath} encrypt -o ${this.currentConfig.outputFormat} --stdin${this.currentConfig.publicKeyPath ? " --pkcs7-public-key " + this.currentConfig.publicKeyPath : ""}`;
         }
 
         public prepareOutput(output: string): string {


### PR DESCRIPTION
Fall back to default params defined in the eyaml configuration file.
ref: https://github.com/voxpupuli/hiera-eyaml#configuration-file-for-eyaml

_Not sure if this is still maintained or not, but figured I'd give a try at least_